### PR TITLE
Replace String.match() with RegExp.test()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var isNative = /\.node$/
+
 function forEach(obj, callback) {
     for ( var key in obj ) {
         if (!Object.prototype.hasOwnProperty.call(obj, key)) {
@@ -10,19 +12,15 @@ function forEach(obj, callback) {
 }
 
 function assign(target, source) {
-    var keys = [];
     forEach(source, function (key) {
-        keys.push(key);
+        target[key] = source[key];
     });
-    for ( var i = 0; i < keys.length; i+=1 ) {
-        target[keys[i]] = source[keys[i]];
-    }
     return target;
 }
 
 function clearCache(requireCache) {
     forEach(requireCache, function (resolvedPath) {
-        if (resolvedPath.match(/\.node$/) === null) {
+        if (!isNative.test(resolvedPath)) {
             delete requireCache[resolvedPath];
         }
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ var isNative = /\.node$/;
 
 function forEach(obj, callback) {
     for ( var key in obj ) {
+        /* istanbul ignore next */
         if (!Object.prototype.hasOwnProperty.call(obj, key)) {
             continue;
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var isNative = /\.node$/
+var isNative = /\.node$/;
 
 function forEach(obj, callback) {
     for ( var key in obj ) {


### PR DESCRIPTION
It's faster and doesn't allocate a new array in memory every time the string matches the regular expression. http://stackoverflow.com/a/10940138/1397319

I've also removed an extraneous loop in the `assign()` function.
